### PR TITLE
Redirect back to current origin in oauth flow

### DIFF
--- a/config/auth/config.go
+++ b/config/auth/config.go
@@ -2,10 +2,9 @@ package auth
 
 import (
 	"golang.org/x/oauth2"
-	"net/url"
 )
 
 type Config interface {
-	GetOAuthConfig() *oauth2.Config
-	GetRedirectUrl() *url.URL
+	GetOAuthConfig(origin string) *oauth2.Config
+	GetRedirectEndpoint() string
 }

--- a/config/auth/oauth_config.go
+++ b/config/auth/oauth_config.go
@@ -7,23 +7,23 @@ import (
 )
 
 type OAuthConfig struct {
-	ClientID     string   `env:"CLIENT_ID"`
-	ClientSecret string   `env:"CLIENT_SECRET"`
-	RedirectURL  *url.URL `env:"REDIRECT_URL,expand" envDefault:"$PUBLIC_URL/api/v1/auth/gitlab/callback"`
-	AuthURL      *url.URL `env:"AUTH_URL,expand" envDefault:"$GITLAB_URL/oauth/authorize"`
-	TokenURL     *url.URL `env:"TOKEN_URL,expand" envDefault:"$GITLAB_URL/oauth/token"`
-	Scopes       []string `env:"SCOPES" envSeparator:"," envDefault:"api"`
+	ClientID         string   `env:"CLIENT_ID"`
+	ClientSecret     string   `env:"CLIENT_SECRET"`
+	RedirectEndpoint string   `env:"REDIRECT_ENDPOINT" envDefault:"/api/v1/auth/gitlab/callback"`
+	AuthURL          *url.URL `env:"AUTH_URL,expand" envDefault:"$GITLAB_URL/oauth/authorize"`
+	TokenURL         *url.URL `env:"TOKEN_URL,expand" envDefault:"$GITLAB_URL/oauth/token"`
+	Scopes           []string `env:"SCOPES" envSeparator:"," envDefault:"api"`
 }
 
-func (c *OAuthConfig) GetRedirectUrl() *url.URL {
-	return c.RedirectURL
+func (c *OAuthConfig) GetRedirectEndpoint() string {
+	return c.RedirectEndpoint
 }
 
-func (c *OAuthConfig) GetOAuthConfig() *oauth2.Config {
+func (c *OAuthConfig) GetOAuthConfig(origin string) *oauth2.Config {
 	return &oauth2.Config{
 		ClientID:     c.ClientID,
 		ClientSecret: c.ClientSecret,
-		RedirectURL:  c.RedirectURL.String(),
+		RedirectURL:  origin + c.RedirectEndpoint,
 		Scopes:       c.Scopes,
 		Endpoint: oauth2.Endpoint{
 			AuthURL:  c.AuthURL.String(),

--- a/controller/auth/oauth_controller.go
+++ b/controller/auth/oauth_controller.go
@@ -22,16 +22,16 @@ import (
 )
 
 type OAuthController struct {
-	authConfig   *oauth2.Config
 	gitlabConfig gitlabConfig.Config
+	authConfig   authConfig.Config
 	g            *singleflight.Group
 }
 
 func NewOAuthController(authConfig authConfig.Config, gitlabConfig gitlabConfig.Config) *OAuthController {
 	g := &singleflight.Group{}
 	return &OAuthController{
-		authConfig:   authConfig.GetOAuthConfig(),
 		gitlabConfig: gitlabConfig,
+		authConfig:   authConfig,
 		g:            g,
 	}
 }
@@ -54,6 +54,7 @@ func (ctrl *OAuthController) SignIn(c *fiber.Ctx) error {
 		redirect = body.Redirect
 	}
 
+	origin := fmt.Sprintf("%s://%s", c.Protocol(), c.Hostname())
 	csrf := c.Locals("csrf").(string)
 
 	stateBytes, err := json.Marshal(authState{csrf, redirect})
@@ -61,16 +62,20 @@ func (ctrl *OAuthController) SignIn(c *fiber.Ctx) error {
 		return fiber.NewError(fiber.StatusInternalServerError, err.Error())
 	}
 
-	authCodeOption := oauth2.S256ChallengeOption("Challenge")              // here include PKCE-Challenge against csrf-attacks should be random
-	url := ctrl.authConfig.AuthCodeURL(string(stateBytes), authCodeOption) // the string state is sent back by the auth-server of gitlab here we could include the redirect url | and or we include a random csrf token that will be validated
+	oauthConfig := ctrl.authConfig.GetOAuthConfig(origin)
+	authCodeOption := oauth2.S256ChallengeOption("Challenge")          // here include PKCE-Challenge against csrf-attacks should be random
+	url := oauthConfig.AuthCodeURL(string(stateBytes), authCodeOption) // the string state is sent back by the auth-server of gitlab here we could include the redirect url | and or we include a random csrf token that will be validated
 
 	return c.Redirect(url, fiber.StatusSeeOther)
 }
 
 // Callback to receive gitlabs' response
 func (ctrl *OAuthController) Callback(c *fiber.Ctx) error {
+	origin := fmt.Sprintf("%s://%s", c.Protocol(), c.Hostname())
+
+	oauthConfig := ctrl.authConfig.GetOAuthConfig(origin)
 	authCodeOption := oauth2.VerifierOption("Challenge") // this is the validation of the PKCE-Challenge
-	token, err := ctrl.authConfig.Exchange(c.Context(), c.FormValue("code"), authCodeOption)
+	token, err := oauthConfig.Exchange(c.Context(), c.FormValue("code"), authCodeOption)
 	if err != nil {
 		return fiber.NewError(fiber.StatusUnauthorized, err.Error())
 	}
@@ -241,7 +246,8 @@ func (ctrl *OAuthController) refreshSession(c context.Context, sess *session.Cla
 	token.Expiry = time.Now().Add(-1 * time.Minute)
 
 	// Refresh token
-	newToken, err := ctrl.authConfig.TokenSource(c, token).Token()
+	oauthConfig := ctrl.authConfig.GetOAuthConfig("")
+	newToken, err := oauthConfig.TokenSource(c, token).Token()
 	if err != nil {
 		oldError := err
 		err = sess.Destroy()

--- a/docker-compose.local.yaml
+++ b/docker-compose.local.yaml
@@ -71,6 +71,7 @@ services:
     #   - "--providers.docker=true"
     #   - "--providers.docker.exposedbydefault=false"
     #   - "--entryPoints.web.address=:6969"
+    #   - "--entryPoints.web.forwardedheaders.insecure=true"
 
     # TODO: Disable on version 3.4
     entrypoint: /bin/sh
@@ -82,7 +83,8 @@ services:
       --providers.file.directory=/etc/traefik
       --providers.docker=true
       --providers.docker.exposedbydefault=false
-      --entryPoints.web.address=:6969"
+      --entryPoints.web.address=:6969
+      --entryPoints.web.forwardedheaders.insecure=true"
     environment:
       APP_SERVICE: |
         http:

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
   server: {
     host: "0.0.0.0",
     proxy: {
-      "/api": `http://127.0.0.1:3000`,
+      "/api": { target: `http://127.0.0.1:3000`, ws: true, xfwd: true },
     },
   },
   resolve: {

--- a/router/router.go
+++ b/router/router.go
@@ -61,13 +61,14 @@ func Routes(
 
 func setupApiRoutes(config authConfig.Config, authController authController.Controller,
 	apiController apiController.Controller) *fiber.App {
+	redirectEndpoint, _ := strings.CutPrefix(config.GetRedirectEndpoint(), "/api/v1")
 
 	app := fiber.New()
 
 	app.Get("/info/gitlab", apiController.GetGitlabInfo)
 	app.Post("/auth/sign-in", authController.SignIn)
 	app.Post("/auth/sign-out", authController.SignOut)
-	app.Get(strings.Replace(config.GetRedirectUrl().Path, "/api/v1", "", 1), authController.Callback)
+	app.Get(redirectEndpoint, authController.Callback)
 	app.Get("/auth/csrf", authController.GetCsrf)
 	app.Use(authController.AuthMiddleware)
 	app.Get("/auth", authController.GetAuth)


### PR DESCRIPTION
This is needed so we can login to the app from 2 valid origins, and not only from the specified publicURL