### PR TITLE
Feature simple Group Invite Link

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,7 +136,7 @@ infra/up:
 	@docker compose -f docker-compose.local.yaml up -d
 
 .PHONY: migrate/new
-migrate/new: migrate/build
+migrate/new:
 	@echo "Migrating up..."
 	@if [ -z "$(name)" ]; then \
 		echo "error: name is required"; \
@@ -146,24 +146,24 @@ migrate/new: migrate/build
 	go tool goose normal create $(name) sql
 
 .PHONY: migrate/status
-migrate/status: migrate/build
+migrate/status:
 	@echo "Migrating status..."
 	go tool goose normal status
 
 .PHONY: seed/up
-seed/up: migrate/build
+seed/up:
 	@echo "Seeding up..."
 	go tool goose seed -no-versioning up
 
 .PHONY: seed/reset
-seed/reset: migrate/build
+seed/reset:
 	@echo "Seeding reset..."
 	go tool goose seed -no-versioning reset
 
 .PHONY: migrate/check
 migrate/check:
 	@echo "Building migrate tool..."
-	@go build -o ./bin/migrate $(MAIN_PACKAGE_PATH)/code_gen/migrations/.
+	# @go build -o ./bin/migrate $(MAIN_PACKAGE_PATH)/code_gen/migrations/.
 	go tool migrations
 
 .PHONY: tidy

--- a/controller/api/default_controller/classroom_get.go
+++ b/controller/api/default_controller/classroom_get.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 
 	"github.com/gofiber/fiber/v2"
+	"github.com/google/uuid"
+	"gitlab.hs-flensburg.de/gitlab-classroom/model/database"
 	"gitlab.hs-flensburg.de/gitlab-classroom/wrapper/context"
 )
 
@@ -23,10 +25,16 @@ func (ctrl *DefaultController) GetClassroom(c *fiber.Ctx) (err error) {
 	ctx := context.Get(c)
 	classroom := ctx.GetUserClassroom()
 
+	var inviteCode *uuid.UUID
+	if classroom.Role <= database.Moderator {
+		inviteCode = &classroom.Classroom.InviteCode
+	}
+
 	response := &UserClassroomResponse{
 		UserClassrooms:   classroom,
 		WebURL:           fmt.Sprintf("/api/v1/classrooms/%s/gitlab", classroom.ClassroomID.String()),
 		AssignmentsCount: len(classroom.Classroom.Assignments),
+		InviteCode:       inviteCode,
 	}
 
 	return c.JSON(response)

--- a/controller/api/default_controller/classroom_invitation_get.go
+++ b/controller/api/default_controller/classroom_invitation_get.go
@@ -1,8 +1,12 @@
 package api
 
 import (
+	"time"
+
 	"github.com/gofiber/fiber/v2"
+	"gitlab.hs-flensburg.de/gitlab-classroom/model/database"
 	"gitlab.hs-flensburg.de/gitlab-classroom/model/database/query"
+	"gitlab.hs-flensburg.de/gitlab-classroom/wrapper/context"
 )
 
 // @Summary		GetClassroomInvitation
@@ -12,6 +16,7 @@ import (
 // @Produce		json
 // @Param			classroomId		path		string	true	"Classroom ID"	Format(uuid)
 // @Param			invitationId	path		string	true	"Invitation ID"	Format(uuid)
+// @Param			groupLink		query		boolean	false	"is Group Link"
 // @Success		200				{object}	ClassroomInvitation
 // @Failure		400				{object}	HTTPError
 // @Failure		401				{object}	HTTPError
@@ -20,7 +25,17 @@ import (
 // @Failure		500				{object}	HTTPError
 // @Router			/api/v1/classrooms/{classroomId}/invitations/{invitationId} [get]
 func (ctrl *DefaultController) GetClassroomInvitation(c *fiber.Ctx) (err error) {
+	ctx := context.Get(c)
 	var params Params
+
+	userID := ctx.GetUserID()
+	queryUser := query.User
+	user, err := queryUser.WithContext(c.Context()).
+		Where(queryUser.ID.Eq(userID)).
+		First()
+	if err != nil {
+		return fiber.NewError(fiber.StatusInternalServerError, err.Error())
+	}
 
 	if err = c.ParamsParser(&params); err != nil {
 		return fiber.NewError(fiber.StatusBadRequest, err.Error())
@@ -30,16 +45,54 @@ func (ctrl *DefaultController) GetClassroomInvitation(c *fiber.Ctx) (err error) 
 		return fiber.ErrBadRequest
 	}
 
-	queryInvitation := query.ClassroomInvitation
-	invitation, err := queryInvitation.
-		WithContext(c.Context()).
-		Preload(queryInvitation.Classroom).
-		Preload(queryInvitation.Classroom.Owner).
-		Where(queryInvitation.ClassroomID.Eq(*params.ClassroomID)).
-		Where(queryInvitation.ID.Eq(*params.InvitationID)).
-		First()
-	if err != nil {
-		return fiber.NewError(fiber.StatusNotFound, err.Error())
+	groupLink := c.QueryBool("groupLink", false)
+	var invitation *database.ClassroomInvitation
+	if groupLink {
+		queryClassroom := query.Classroom
+		classroom, err := queryClassroom.WithContext(c.Context()).
+			Preload(queryClassroom.Owner).
+			Where(queryClassroom.ID.Eq((*params.ClassroomID))).
+			First()
+		if err != nil {
+			return fiber.NewError(fiber.StatusNotFound, err.Error())
+		}
+
+		if classroom.InviteCode != *params.InvitationID {
+			return fiber.NewError(fiber.StatusNotFound, "invitation code revoked or not found")
+		}
+
+		status := database.ClassroomInvitationPending
+		queryUserClassrooms := query.UserClassrooms
+		_, err = queryUserClassrooms.WithContext(c.Context()).
+			Where(queryUserClassrooms.UserID.Eq(userID)).
+			Where(queryUserClassrooms.ClassroomID.Eq(*params.ClassroomID)).
+			First()
+		if err == nil {
+			status = database.ClassroomInvitationAccepted
+		}
+
+		invitation = &database.ClassroomInvitation{
+			ID:          classroom.InviteCode,
+			ClassroomID: *params.ClassroomID,
+			Classroom:   *classroom,
+			CreatedAt:   time.Now(),
+			UpdatedAt:   time.Now(),
+			Status:      status,
+			Email:       user.GitlabEmail,
+			ExpiryDate:  time.Now().AddDate(0, 0, 14),
+		}
+	} else {
+		queryInvitation := query.ClassroomInvitation
+		invitation, err = queryInvitation.
+			WithContext(c.Context()).
+			Preload(queryInvitation.Classroom).
+			Preload(queryInvitation.Classroom.Owner).
+			Where(queryInvitation.ClassroomID.Eq(*params.ClassroomID)).
+			Where(queryInvitation.ID.Eq(*params.InvitationID)).
+			First()
+		if err != nil {
+			return fiber.NewError(fiber.StatusNotFound, err.Error())
+		}
 	}
 
 	return c.JSON(invitation)

--- a/controller/api/default_controller/classroom_invitations_post.go
+++ b/controller/api/default_controller/classroom_invitations_post.go
@@ -144,8 +144,10 @@ func (ctrl *DefaultController) sendMailsWorker(classroom *database.Classroom, in
 				InvitationPath:     fmt.Sprintf("/classrooms/%s/invitations/%s", classroom.ID.String(), invitation.ID.String()),
 				ExpireDate:         invitation.ExpiryDate,
 			}
+
+			var err error
 			for range 3 {
-				if err := ctrl.mailRepo.SendClassroomInvitation(
+				if err = ctrl.mailRepo.SendClassroomInvitation(
 					email,
 					fmt.Sprintf(`New Invitation for Classroom "%s"`, classroom.Name),
 					data,
@@ -155,7 +157,7 @@ func (ctrl *DefaultController) sendMailsWorker(classroom *database.Classroom, in
 				}
 			}
 
-			log.Println("Could not send invitation to", email)
+			log.Println("Could not send invitation to", email, err)
 			invitation.Status = database.ClassroomInvitationFailed
 			if _, err := query.ClassroomInvitation.WithContext(context.Background()).Updates(invitation); err != nil {
 				log.Println("Could not update invitation status")

--- a/controller/api/default_controller/classroom_join_post.go
+++ b/controller/api/default_controller/classroom_join_post.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"fmt"
+	"log"
 	"time"
 
 	"github.com/gofiber/fiber/v2"
@@ -21,8 +22,9 @@ const (
 )
 
 type joinClassroomRequest struct {
-	InvitationID uuid.UUID `json:"invitationId"`
-	Action       action    `json:"action"`
+	InvitationID  uuid.UUID `json:"invitationId"`
+	Action        action    `json:"action"`
+	ClassroomCode bool      `json:"classroomCode"`
 } //@Name JoinClassroomRequest
 
 func (r *joinClassroomRequest) isValid() bool {
@@ -68,30 +70,6 @@ func (ctrl *DefaultController) JoinClassroom(c *fiber.Ctx) (err error) {
 		return fiber.ErrBadRequest
 	}
 
-	queryClassroomInvitation := query.ClassroomInvitation
-	invitation, err := queryClassroomInvitation.
-		WithContext(c.Context()).
-		Preload(queryClassroomInvitation.Classroom).
-		Where(queryClassroomInvitation.ClassroomID.Eq(*params.ClassroomID)).
-		Where(queryClassroomInvitation.ID.Eq(requestBody.InvitationID)).
-		First()
-	if err != nil {
-		return fiber.NewError(fiber.StatusNotFound, err.Error())
-	}
-
-	switch invitation.Status {
-	case database.ClassroomInvitationRevoked:
-		return fiber.NewError(fiber.StatusForbidden, "This invitation has been revoked.")
-	case database.ClassroomInvitationPending:
-		break
-	default:
-		return fiber.NewError(fiber.StatusForbidden, "This invitation has already been processed.")
-	}
-
-	if time.Now().After(invitation.ExpiryDate) {
-		return fiber.NewError(fiber.StatusForbidden, "The link to this classroom expired. Please ask the owner for a new invitation link.")
-	}
-
 	userID := ctx.GetUserID()
 	queryUser := query.User
 	user, err := queryUser.WithContext(c.Context()).
@@ -101,27 +79,103 @@ func (ctrl *DefaultController) JoinClassroom(c *fiber.Ctx) (err error) {
 		return fiber.NewError(fiber.StatusInternalServerError, err.Error())
 	}
 
-	queryUserClassrooms := query.UserClassrooms
-	_, err = queryUserClassrooms.WithContext(c.Context()).
-		Where(queryUserClassrooms.UserID.Eq(userID)).
-		Where(queryUserClassrooms.ClassroomID.Eq(invitation.ClassroomID)).
-		First()
-	if err == nil {
-		if _, err := queryClassroomInvitation.WithContext(c.Context()).Delete(invitation); err != nil {
-			return fiber.NewError(fiber.StatusInternalServerError, err.Error())
+	queryClassroomInvitation := query.ClassroomInvitation
+	var invitation *database.ClassroomInvitation
+	if requestBody.ClassroomCode {
+		if requestBody.Action == reject {
+			return c.SendStatus(fiber.StatusAccepted)
 		}
 
-		return fiber.NewError(fiber.StatusForbidden, "You are already a member of this classroom.")
-	}
-
-	if requestBody.Action == reject {
-		invitation.Status = database.ClassroomInvitationRejected
-		invitation.Email = user.GitlabEmail
-		err = queryClassroomInvitation.WithContext(c.Context()).Save(invitation)
+		queryClassroom := query.Classroom
+		classroom, err := queryClassroom.WithContext(c.Context()).
+			Where(queryClassroom.ID.Eq(*params.ClassroomID)).
+			First()
 		if err != nil {
-			return fiber.NewError(fiber.StatusInternalServerError, err.Error())
+			return fiber.NewError(fiber.StatusNotFound, err.Error())
 		}
-		return c.SendStatus(fiber.StatusAccepted)
+
+		if classroom.InviteCode != requestBody.InvitationID {
+			return fiber.NewError(fiber.StatusForbidden, "This invitation has been revoked or does not exist.")
+		}
+
+		queryUserClassrooms := query.UserClassrooms
+		_, err = queryUserClassrooms.WithContext(c.Context()).
+			Where(queryUserClassrooms.UserID.Eq(userID)).
+			Where(queryUserClassrooms.ClassroomID.Eq(*params.ClassroomID)).
+			First()
+		if err == nil {
+			return fiber.NewError(fiber.StatusForbidden, "You are already a member of this classroom.")
+		}
+
+		invitation = &database.ClassroomInvitation{
+			Status:      database.ClassroomInvitationAccepted,
+			ClassroomID: *params.ClassroomID,
+			Classroom:   *classroom,
+			Email:       user.GitlabEmail,
+			ExpiryDate:  time.Now().AddDate(0, 0, 14),
+		}
+
+		if err := queryClassroomInvitation.
+			WithContext(c.Context()).
+			Save(invitation); err != nil {
+			return fiber.NewError(fiber.StatusNotFound, err.Error())
+		}
+
+		defer func() {
+			if recover() != nil || err != nil {
+				if queryClassroomInvitation.
+					WithContext(c.Context()).
+					Delete(invitation); err != nil {
+					log.Println(err.Error())
+				}
+			}
+		}()
+	} else {
+		invitation, err = queryClassroomInvitation.
+			WithContext(c.Context()).
+			Preload(queryClassroomInvitation.Classroom).
+			Where(queryClassroomInvitation.ClassroomID.Eq(*params.ClassroomID)).
+			Where(queryClassroomInvitation.ID.Eq(requestBody.InvitationID)).
+			First()
+		if err != nil {
+			return fiber.NewError(fiber.StatusNotFound, err.Error())
+		}
+
+		switch invitation.Status {
+		case database.ClassroomInvitationRevoked:
+			return fiber.NewError(fiber.StatusForbidden, "This invitation has been revoked.")
+		case database.ClassroomInvitationPending:
+			break
+		default:
+			return fiber.NewError(fiber.StatusForbidden, "This invitation has already been processed.")
+		}
+
+		if time.Now().After(invitation.ExpiryDate) {
+			return fiber.NewError(fiber.StatusForbidden, "The link to this classroom expired. Please ask the owner for a new invitation link.")
+		}
+
+		queryUserClassrooms := query.UserClassrooms
+		_, err = queryUserClassrooms.WithContext(c.Context()).
+			Where(queryUserClassrooms.UserID.Eq(userID)).
+			Where(queryUserClassrooms.ClassroomID.Eq(invitation.ClassroomID)).
+			First()
+		if err == nil {
+			if _, err := queryClassroomInvitation.WithContext(c.Context()).Delete(invitation); err != nil {
+				return fiber.NewError(fiber.StatusInternalServerError, err.Error())
+			}
+
+			return fiber.NewError(fiber.StatusForbidden, "You are already a member of this classroom.")
+		}
+
+		if requestBody.Action == reject {
+			invitation.Status = database.ClassroomInvitationRejected
+			invitation.Email = user.GitlabEmail
+			err = queryClassroomInvitation.WithContext(c.Context()).Save(invitation)
+			if err != nil {
+				return fiber.NewError(fiber.StatusInternalServerError, err.Error())
+			}
+			return c.SendStatus(fiber.StatusAccepted)
+		}
 	}
 
 	// reauthenticate the repo with the group access token

--- a/controller/api/default_controller/classrooms_post.go
+++ b/controller/api/default_controller/classrooms_post.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/gofiber/fiber/v2"
+	"github.com/google/uuid"
 	"gitlab.hs-flensburg.de/gitlab-classroom/model/database"
 	"gitlab.hs-flensburg.de/gitlab-classroom/model/database/query"
 	"gitlab.hs-flensburg.de/gitlab-classroom/repository/gitlab/model"
@@ -114,6 +115,7 @@ func (ctrl *DefaultController) CreateClassroom(c *fiber.Ctx) (err error) {
 			GroupAccessToken:        accessToken.Token,
 			StudentsViewAllProjects: *requestBody.StudentsViewAllProjects,
 			Member:                  []*database.UserClassrooms{{UserID: userID, Role: database.Owner}},
+			InviteCode:              uuid.New(),
 		}
 
 		if err = classroomQuery.WithContext(c.Context()).Create(classroom); err != nil {

--- a/controller/api/default_controller/default_controller.go
+++ b/controller/api/default_controller/default_controller.go
@@ -52,6 +52,7 @@ type ProjectResponse struct {
 
 type UserClassroomResponse struct {
 	*database.UserClassrooms
-	WebURL           string `json:"webUrl"`
-	AssignmentsCount int    `json:"assignmentsCount"`
+	WebURL           string     `json:"webUrl"`
+	AssignmentsCount int        `json:"assignmentsCount"`
+	InviteCode       *uuid.UUID `json:"inviteCode"`
 } //@Name UserClassroomResponse

--- a/frontend/src/api/classroom.ts
+++ b/frontend/src/api/classroom.ts
@@ -36,11 +36,11 @@ export const classroomInvitationsQueryOptions = (classroomId: string) =>
     },
   });
 
-export const classroomInvitationQueryOptions = (classroomId: string, invitationId: string) =>
+export const classroomInvitationQueryOptions = (classroomId: string, invitationId: string, groupLink: boolean) =>
   queryOptions({
     queryKey: ["classrooms", classroomId, "invitations", invitationId],
     queryFn: async () => {
-      const res = await apiClient.getClassroomInvitation(classroomId, invitationId);
+      const res = await apiClient.getClassroomInvitation(classroomId, invitationId, groupLink);
       return res.data;
     },
   });
@@ -137,18 +137,18 @@ export const useInviteClassroomMembers = (classroomId: string) => {
   });
 };
 
-export const useJoinClassroom = (classroomId: string, invitationId: string) => {
+export const useJoinClassroom = (classroomId: string, invitationId: string, classroomCode: boolean) => {
   const queryClient = useQueryClient();
   const { csrfToken } = useCsrf();
   return useMutation({
     mutationFn: async (action: Action) => {
-      const res = await apiClient.joinClassroom({ invitationId, action }, csrfToken, classroomId);
+      const res = await apiClient.joinClassroom({ invitationId, action, classroomCode }, csrfToken, classroomId);
       return res.headers.location as string;
     },
     onSuccess: () => {
       queryClient.invalidateQueries(classroomsQueryOptions());
       queryClient.invalidateQueries(classroomsQueryOptions(Filter.Student));
-      queryClient.invalidateQueries(classroomInvitationQueryOptions(classroomId, invitationId));
+      queryClient.invalidateQueries(classroomInvitationQueryOptions(classroomId, invitationId, classroomCode));
     },
     onSettled: () => {
       queryClient.invalidateQueries(authCsrfQueryOptions);

--- a/frontend/src/routes/_auth/classrooms/$classroomId/index.tsx
+++ b/frontend/src/routes/_auth/classrooms/$classroomId/index.tsx
@@ -1,6 +1,6 @@
 import { Loader } from "@/components/loader";
 import { useSuspenseQuery } from "@tanstack/react-query";
-import { createFileRoute, Outlet, Link } from "@tanstack/react-router";
+import { createFileRoute, Outlet, Link, useRouter } from "@tanstack/react-router";
 import { MemberListCard } from "@/components/classroomMembers.tsx";
 import { TeamListCard } from "@/components/classroomTeams.tsx";
 import { AssignmentListSection } from "@/components/classroomAssignments.tsx";
@@ -15,6 +15,7 @@ import {
   Archive,
   CalendarCheck2,
   CalendarClock,
+  Clipboard,
   Download,
   ExternalLink,
   Eye,
@@ -45,6 +46,7 @@ import { useLocalStorage } from "@/hooks/useLocalStorage";
 import { projectsQueryOptions } from "@/api/project";
 import { Breadcrumb, BreadcrumbItem, BreadcrumbList, BreadcrumbPage } from "@/components/ui/breadcrumb";
 import { ProjectListSection } from "@/components/classroomProjects";
+import { toast } from "sonner";
 
 const tabs = ["assignments", "members", "teams"] as const;
 const tabSchema = z.enum(tabs);
@@ -91,6 +93,7 @@ function ClassroomDetail() {
   const [showHeaderCards, setShowHeaderCards] = useLocalStorage("classroom-header", true);
   const toggleHeaderCards = () => setShowHeaderCards((old) => !old);
   const { teamsReportUrls } = Route.useLoaderData();
+  const router = useRouter();
 
   const handleConfirmArchive = () => {
     mutate();
@@ -144,6 +147,21 @@ function ClassroomDetail() {
           </Button>
           {!userClassroom.classroom.archived && isModerator(userClassroom) && (
             <>
+              <Button variant="secondary" size="sm" title="Copy InviteLink"
+                onClick={() => {
+                  const path = router.buildLocation({
+                    to: "/classrooms/$classroomId/invitations/$invitationId",
+                    params: { classroomId: userClassroom.classroom.id, invitationId: userClassroom.inviteCode },
+                    search: { groupLink: true }
+                  });
+
+                  navigator.clipboard.writeText(`${location.origin}${path.href}`);
+                  toast.success("Link copied to clipboard");
+                }}
+              >
+                <Clipboard className="mr-2 h-4 w-4" />
+                Copy Invite Link
+              </Button>
               <Button variant="secondary" asChild size="sm" title="Download report">
                 <a href={reportDownloadUrl} target="_blank" referrerPolicy="no-referrer">
                   <Download className="mr-2 h-4 w-4" />

--- a/frontend/src/routes/_auth/classrooms/$classroomId/invite.tsx
+++ b/frontend/src/routes/_auth/classrooms/$classroomId/invite.tsx
@@ -143,6 +143,7 @@ function InvitationsTable({
           const path = router.buildLocation({
             to: "/classrooms/$classroomId/invitations/$invitationId",
             params: { classroomId: userClassroom.classroom.id, invitationId: i.id },
+            search: { groupLink: false }
           });
           return (
             <TableRow key={i.email}>
@@ -154,7 +155,7 @@ function InvitationsTable({
                   <Button
                     variant="outline"
                     onClick={() => {
-                      navigator.clipboard.writeText(`${location.origin}${path.pathname}`);
+                      navigator.clipboard.writeText(`${location.origin}${path.href}`);
                       toast.success("Link copied to clipboard");
                     }}
                   >

--- a/frontend/src/routes/_auth/classrooms/$classroomId_.invitations.$invitationId.tsx
+++ b/frontend/src/routes/_auth/classrooms/$classroomId_.invitations.$invitationId.tsx
@@ -9,11 +9,18 @@ import { useSuspenseQuery } from "@tanstack/react-query";
 import { classroomInvitationQueryOptions, useJoinClassroom } from "@/api/classroom";
 import GitlabLogo from "@/assets/gitlab_logo.svg";
 import { AxiosError } from "axios";
+import { z } from "zod";
+
+const seachSchema = z.object({
+  groupLink: z.boolean().catch(false)
+})
 
 export const Route = createFileRoute("/_auth/classrooms/$classroomId/invitations/$invitationId")({
-  loader: async ({ context: { queryClient }, params }) => {
+  validateSearch: seachSchema,
+  loaderDeps: ({ search }) => ({ search }),
+  loader: async ({ context: { queryClient }, params, deps: { search: { groupLink } } }) => {
     const invitationInfo = await queryClient.ensureQueryData(
-      classroomInvitationQueryOptions(params.classroomId, params.invitationId),
+      classroomInvitationQueryOptions(params.classroomId, params.invitationId, groupLink),
     );
     return { invitationInfo };
   },
@@ -23,8 +30,9 @@ export const Route = createFileRoute("/_auth/classrooms/$classroomId/invitations
 function JoinClassroom() {
   const navigate = useNavigate();
   const { classroomId, invitationId } = Route.useParams();
-  const { data: invitation } = useSuspenseQuery(classroomInvitationQueryOptions(classroomId, invitationId));
-  const { mutateAsync, isError, isPending, error } = useJoinClassroom(classroomId, invitationId);
+  const { groupLink } = Route.useSearch();
+  const { data: invitation } = useSuspenseQuery(classroomInvitationQueryOptions(classroomId, invitationId, groupLink));
+  const { mutateAsync, isError, isPending, error } = useJoinClassroom(classroomId, invitationId, groupLink);
 
   const onAccept = async () => {
     const location = await mutateAsync(Action.Accept);

--- a/frontend/src/swagger-client/apis/classroom-api.ts
+++ b/frontend/src/swagger-client/apis/classroom-api.ts
@@ -178,10 +178,11 @@ export const ClassroomApiAxiosParamCreator = function (configuration?: Configura
          * @summary GetClassroomInvitation
          * @param {string} classroomId Classroom ID
          * @param {string} invitationId Invitation ID
+         * @param {boolean} [groupLink] is Group Link
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getClassroomInvitation: async (classroomId: string, invitationId: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        getClassroomInvitation: async (classroomId: string, invitationId: string, groupLink?: boolean, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'classroomId' is not null or undefined
             if (classroomId === null || classroomId === undefined) {
                 throw new RequiredError('classroomId','Required parameter classroomId was null or undefined when calling getClassroomInvitation.');
@@ -202,6 +203,10 @@ export const ClassroomApiAxiosParamCreator = function (configuration?: Configura
             const localVarRequestOptions :AxiosRequestConfig = { method: 'GET', ...baseOptions, ...options};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
+
+            if (groupLink !== undefined) {
+                localVarQueryParameter['groupLink'] = groupLink;
+            }
 
             const query = new URLSearchParams(localVarUrlObj.search);
             for (const key in localVarQueryParameter) {
@@ -575,11 +580,12 @@ export const ClassroomApiFp = function(configuration?: Configuration) {
          * @summary GetClassroomInvitation
          * @param {string} classroomId Classroom ID
          * @param {string} invitationId Invitation ID
+         * @param {boolean} [groupLink] is Group Link
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async getClassroomInvitation(classroomId: string, invitationId: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => Promise<AxiosResponse<ClassroomInvitation>>> {
-            const localVarAxiosArgs = await ClassroomApiAxiosParamCreator(configuration).getClassroomInvitation(classroomId, invitationId, options);
+        async getClassroomInvitation(classroomId: string, invitationId: string, groupLink?: boolean, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => Promise<AxiosResponse<ClassroomInvitation>>> {
+            const localVarAxiosArgs = await ClassroomApiAxiosParamCreator(configuration).getClassroomInvitation(classroomId, invitationId, groupLink, options);
             return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
                 const axiosRequestArgs :AxiosRequestConfig = {...localVarAxiosArgs.options, url: basePath + localVarAxiosArgs.url};
                 return axios.request(axiosRequestArgs);
@@ -722,11 +728,12 @@ export const ClassroomApiFactory = function (configuration?: Configuration, base
          * @summary GetClassroomInvitation
          * @param {string} classroomId Classroom ID
          * @param {string} invitationId Invitation ID
+         * @param {boolean} [groupLink] is Group Link
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async getClassroomInvitation(classroomId: string, invitationId: string, options?: AxiosRequestConfig): Promise<AxiosResponse<ClassroomInvitation>> {
-            return ClassroomApiFp(configuration).getClassroomInvitation(classroomId, invitationId, options).then((request) => request(axios, basePath));
+        async getClassroomInvitation(classroomId: string, invitationId: string, groupLink?: boolean, options?: AxiosRequestConfig): Promise<AxiosResponse<ClassroomInvitation>> {
+            return ClassroomApiFp(configuration).getClassroomInvitation(classroomId, invitationId, groupLink, options).then((request) => request(axios, basePath));
         },
         /**
          * GetClassroomInvitations
@@ -845,12 +852,13 @@ export class ClassroomApi extends BaseAPI {
      * @summary GetClassroomInvitation
      * @param {string} classroomId Classroom ID
      * @param {string} invitationId Invitation ID
+     * @param {boolean} [groupLink] is Group Link
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof ClassroomApi
      */
-    public async getClassroomInvitation(classroomId: string, invitationId: string, options?: AxiosRequestConfig) : Promise<AxiosResponse<ClassroomInvitation>> {
-        return ClassroomApiFp(this.configuration).getClassroomInvitation(classroomId, invitationId, options).then((request) => request(this.axios, this.basePath));
+    public async getClassroomInvitation(classroomId: string, invitationId: string, groupLink?: boolean, options?: AxiosRequestConfig) : Promise<AxiosResponse<ClassroomInvitation>> {
+        return ClassroomApiFp(this.configuration).getClassroomInvitation(classroomId, invitationId, groupLink, options).then((request) => request(this.axios, this.basePath));
     }
     /**
      * GetClassroomInvitations

--- a/frontend/src/swagger-client/models/join-classroom-request.ts
+++ b/frontend/src/swagger-client/models/join-classroom-request.ts
@@ -28,6 +28,12 @@ export interface JoinClassroomRequest {
     action: Action;
 
     /**
+     * @type {boolean}
+     * @memberof JoinClassroomRequest
+     */
+    classroomCode: boolean;
+
+    /**
      * @type {string}
      * @memberof JoinClassroomRequest
      */

--- a/frontend/src/swagger-client/models/user-classroom-response.ts
+++ b/frontend/src/swagger-client/models/user-classroom-response.ts
@@ -37,6 +37,12 @@ export interface UserClassroomResponse {
     classroom: Classroom;
 
     /**
+     * @type {string}
+     * @memberof UserClassroomResponse
+     */
+    inviteCode: string;
+
+    /**
      * @type {Role}
      * @memberof UserClassroomResponse
      */

--- a/model/database/classroom.go
+++ b/model/database/classroom.go
@@ -34,6 +34,8 @@ type Classroom struct {
 	ManualGradingRubrics    []*ManualGradingRubric `gorm:"constraint:OnDelete:CASCADE;" json:"-"`
 	StudentsViewAllProjects bool                   `gorm:"not null" json:"studentsViewAllProjects"`
 
+	InviteCode uuid.UUID `gorm:"type:uuid;not null;default:uuid_generate_v4()" json:"-"`
+
 	Archived           bool `gorm:"not null;default:false" json:"archived"`
 	PotentiallyDeleted bool `gorm:"not null;default:false" json:"potentiallyDeleted"`
 } //@Name Classroom

--- a/model/database/migrations/20250904184606_classroom_invite_link.sql
+++ b/model/database/migrations/20250904184606_classroom_invite_link.sql
@@ -1,0 +1,5 @@
+-- +goose Up
+ALTER TABLE "public"."classrooms" ADD COLUMN "invite_code" UUID NOT NULL DEFAULT uuid_generate_v4();
+
+-- +goose Down
+ALTER TABLE "public"."classrooms" DROP COLUMN "invite_code";


### PR DESCRIPTION
This PR adds a new field to the classroom with an invite code, this code can be used instead of an personalized invitation, so everyone with this code can join the classroom. No endpoint was added but the endpoints `invitation_get` and `join_post` accept an extra parameter and handle the code of the classroom instead of the invitation id.